### PR TITLE
FIx bound check logic for smartvio brain-1 tool

### DIFF
--- a/src/smartvio-brain.cpp
+++ b/src/smartvio-brain.cpp
@@ -349,11 +349,11 @@ int applyVIO (int i2c_file, uint32_t svio1, uint32_t svio2)
 	uint8_t temp_data[2];
 	
 	// Bounds check to be sure that everything is good to go
-	if (svio1 != 0 && (svio1 < 120) || (svio1 > 330)) {
+	if (svio1 != 0 && ((svio1 < 120) || (svio1 > 330))) {
 		printf("Invalid SmartVIO solution\n");
 		exit(EXIT_FAILURE);
 	}
-	if (svio2 != 0 && (svio2 < 120) || (svio2 > 330)) {
+	if (svio2 != 0 && ((svio2 < 120) || (svio2 > 330))) {
 		printf("Invalid SmartVIO solution\n");
 		exit(EXIT_FAILURE);
 	}

--- a/src/smartvio-brain.cpp
+++ b/src/smartvio-brain.cpp
@@ -349,11 +349,11 @@ int applyVIO (int i2c_file, uint32_t svio1, uint32_t svio2)
 	uint8_t temp_data[2];
 	
 	// Bounds check to be sure that everything is good to go
-	if (svio1 != 0 && ((svio1 < 120) || (svio1 > 330))) {
+	if ((svio1 != 0) && ((svio1 < 120) || (svio1 > 330))) {
 		printf("Invalid SmartVIO solution\n");
 		exit(EXIT_FAILURE);
 	}
-	if (svio2 != 0 && ((svio2 < 120) || (svio2 > 330))) {
+	if ((svio2 != 0) && ((svio2 < 120) || (svio2 > 330))) {
 		printf("Invalid SmartVIO solution\n");
 		exit(EXIT_FAILURE);
 	}

--- a/src/smartvio-brain.cpp
+++ b/src/smartvio-brain.cpp
@@ -349,11 +349,11 @@ int applyVIO (int i2c_file, uint32_t svio1, uint32_t svio2)
 	uint8_t temp_data[2];
 	
 	// Bounds check to be sure that everything is good to go
-	if ((svio1 < 120) || (svio1 > 330)) {
+	if (svio1 != 0 && (svio1 < 120) || (svio1 > 330)) {
 		printf("Invalid SmartVIO solution\n");
 		exit(EXIT_FAILURE);
 	}
-	if ((svio2 < 120) || (svio2 > 330)) {
+	if (svio2 != 0 && (svio2 < 120) || (svio2 > 330)) {
 		printf("Invalid SmartVIO solution\n");
 		exit(EXIT_FAILURE);
 	}


### PR DESCRIPTION
This allows a single VIO to be set using the `-s` option. Otherwise, both VIOs must be set, as the `svio` variables are set to zero at program execution. This fix allows brings the program behavior inline with the help message which implies setting one VIO at a time is possible. Tested on a Brain-1 and checked VIO voltages with a multimeter. 